### PR TITLE
Update TDNotificationPanel to correctly resize on rotation of device.

### DIFF
--- a/TDNotificationPanel/TDNotificationPanel.m
+++ b/TDNotificationPanel/TDNotificationPanel.m
@@ -460,9 +460,10 @@ static const CGFloat kSpacing = 4.f;
 - (void)positionElements
 {
     // Determine the total width of the notification.
-	CGSize size = { .width = self.superview.bounds.size.width ?: self.bounds.size.width, .height = kYPadding };
+	CGSize size = { .width = CGRectGetWidth(self.superview.bounds) ?: CGRectGetWidth(self.bounds), .height = kYPadding };
 
-	CGRect rect = { .size = CGSizeMake(size.width, self.frame.size.height), .origin = self.frame.origin };
+	// update notification panel frame in case of rotation
+	CGRect rect = { .size = CGSizeMake(size.width, CGRectGetHeight(self.frame)), .origin = self.frame.origin };
 	self.frame = rect;
 	
     // Icon

--- a/TDNotificationPanel/TDNotificationPanel.m
+++ b/TDNotificationPanel/TDNotificationPanel.m
@@ -460,8 +460,11 @@ static const CGFloat kSpacing = 4.f;
 - (void)positionElements
 {
     // Determine the total width of the notification.
-    CGSize size = { .width = self.bounds.size.width, .height = kYPadding };
-    
+	CGSize size = { .width = self.superview.bounds.size.width ?: self.bounds.size.width, .height = kYPadding };
+
+	CGRect rect = { .size = CGSizeMake(size.width, self.frame.size.height), .origin = self.frame.origin };
+	self.frame = rect;
+	
     // Icon
     if ([_icon image])
     {
@@ -570,6 +573,13 @@ static const CGFloat kSpacing = 4.f;
     
     [self positionElements];
     self.frame = CGRectMake(0, 0, _totalSize.width, _totalSize.height);
+}
+
+#pragma - layout subviews
+- (void)layoutSubviews
+{
+	[super layoutSubviews];
+	[self positionElements];
 }
 
 @end


### PR DESCRIPTION
Previously rotating from portrait to landscape would mean the panel would not extend the full width of the screen.
